### PR TITLE
add tc.preset to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ The legendary [JSUI MGraphics patch a day from Darwin Grosse](https://cycling74.
 - [No Code Knob Creation Tool | Neil Baldwin](https://github.com/neilbaldwin/JSUI_UN_KNOB)
 - [Lode Max for Live device & framework | Fors](https://github.com/fors-fm/lode)
 - [Image Upscaling | Tyler Mazaika](https://github.com/tylermazaika/mgraphics-examples/tree/main)
+- [tc.preset | Théophile Clet](https://github.com/Teufeuleu/tc.preset)


### PR DESCRIPTION
Request to add tc.preset, a jsui remake of the [preset] object, but with more features.
I hope the code isn't too clunky, I'm not the most rigorous about naming convention, code factorisation and organization, but it shows a variety of techniques working together: upscaled rendering for HiDPI screen, two layers rendering to prevent redrawing things that haven't changed, automatic resize in both normal and presentation mode, mouse ,scroll and modifier key interaction, pattr integration...